### PR TITLE
Add admin login and routing scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,56 @@
-# React + Vite
+# Link Shortener Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This repository contains the React frontend for the link shortener application. The project uses **Vite** for bundling and **Tailwind CSS** for styling.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **Shortener Form** – main page that allows users to create shortened URLs (`src/ShortenerForm.jsx`).
+- **Admin Dashboard** – protected page displaying link analytics and a click trends graph (`src/pages/AdminDashboard.jsx`).
+- **Admin Login** – form for authenticating administrators (`src/pages/AdminLogin.jsx`).
+- **404 Page** – shown when no route matches (`src/pages/NotFound.jsx`).
+- Toast notifications using `react-toastify`.
 
-## Expanding the ESLint configuration
+## Getting Started
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:5173/` by default.
+3. Lint the project:
+   ```bash
+   npm run lint
+   ```
+4. Build for production:
+   ```bash
+   npm run build
+   ```
+
+## Project Structure
+
+```
+src/
+  App.jsx               # Application with routes and toasts
+  ShortenerForm.jsx     # Form for creating shortened links
+  components/
+    PrivateRoute.jsx    # Protects admin routes
+  pages/
+    AdminLogin.jsx      # Admin login form
+    AdminDashboard.jsx  # Dashboard with analytics table and chart
+    NotFound.jsx        # 404 fallback page
+```
+
+## API Expectations
+
+The Admin Dashboard expects the following endpoints:
+
+- `GET /api/links` – returns an array of links with `originalUrl`, `shortCode`, `clicks` and `createdAt`.
+- `GET /api/analytics/trend` – returns click data for the trend graph.
+- `POST /api/admin/login` – returns `{ token }` used for authentication.
+- `POST /api/shorten` – accepts `{ url }` and returns `{ shortUrl }`.
+
+Ensure the backend is running and accessible for the dashboard and login to work correctly.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://cdn.tailwindcss.com"></script>
     <title>Vite + React</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.10.0",
+        "chart.js": "^4.5.0",
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-chartjs-2": "^5.3.0",
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
+        "react-toastify": "^9.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1061,6 +1066,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz",
@@ -1954,6 +1974,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -1962,6 +1994,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2844,6 +2885,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3456,6 +3506,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -3476,6 +3536,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,13 @@
   },
   "dependencies": {
     "axios": "^1.10.0",
+    "chart.js": "^4.5.0",
+    "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-chartjs-2": "^5.3.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
+    "react-toastify": "^9.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,31 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 import ShortenerForm from './ShortenerForm.jsx'
+import AdminLogin from './pages/AdminLogin.jsx'
+import AdminDashboard from './pages/AdminDashboard.jsx'
+import NotFound from './pages/NotFound.jsx'
+import PrivateRoute from './components/PrivateRoute.jsx'
 import './App.css'
 
 function App() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <ShortenerForm />
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<ShortenerForm />} />
+        <Route path="/admin/login" element={<AdminLogin />} />
+        <Route
+          path="/admin"
+          element={
+            <PrivateRoute>
+              <AdminDashboard />
+            </PrivateRoute>
+          }
+        />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+      <ToastContainer position="bottom-right" />
+    </BrowserRouter>
   )
 }
 

--- a/src/ShortenerForm.jsx
+++ b/src/ShortenerForm.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import axios from 'axios'
+import { toast } from 'react-toastify'
+
+function ShortenerForm() {
+  const [url, setUrl] = useState('')
+  const [shortUrl, setShortUrl] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const res = await axios.post('/api/shorten', { url })
+      setShortUrl(res.data.shortUrl)
+      toast.success('URL shortened!')
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Error shortening URL')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-4 w-full max-w-md">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="w-full border p-2 rounded"
+          type="url"
+          placeholder="Enter URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          required
+        />
+        <button
+          className="w-full bg-blue-500 text-white py-2 rounded disabled:opacity-50"
+          type="submit"
+          disabled={loading}
+        >
+          {loading ? 'Shortening...' : 'Shorten'}
+        </button>
+      </form>
+      {shortUrl && (
+        <p className="mt-4">
+          Short URL:{' '}
+          <a href={shortUrl} className="text-blue-500">
+            {shortUrl}
+          </a>
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default ShortenerForm

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,0 +1,21 @@
+import { Navigate } from 'react-router-dom'
+import jwtDecode from 'jwt-decode'
+
+function isTokenValid(token) {
+  try {
+    const { exp } = jwtDecode(token)
+    return exp * 1000 > Date.now()
+  } catch {
+    return false
+  }
+}
+
+function PrivateRoute({ children }) {
+  const token = localStorage.getItem('token')
+  if (!token || !isTokenValid(token)) {
+    return <Navigate to="/admin/login" replace />
+  }
+  return children
+}
+
+export default PrivateRoute

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+)
+
+function AdminDashboard() {
+  const [links, setLinks] = useState([])
+  const [trend, setTrend] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const [linksRes, trendRes] = await Promise.all([
+          fetch('/api/links'),
+          fetch('/api/analytics/trend'),
+        ])
+        if (!linksRes.ok) throw new Error('Failed to fetch analytics')
+        if (!trendRes.ok) throw new Error('Failed to fetch trend')
+        setLinks(await linksRes.json())
+        setTrend(await trendRes.json())
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  const chartData = {
+    labels: trend.map((t) => new Date(t.date).toLocaleDateString()),
+    datasets: [
+      {
+        label: 'Clicks',
+        data: trend.map((t) => t.clicks),
+        borderColor: 'rgb(59, 130, 246)',
+        backgroundColor: 'rgba(59, 130, 246, 0.4)',
+      },
+    ],
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      {loading ? (
+        <div className="flex justify-center items-center h-32">
+          <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="text-red-500 text-center">{error}</div>
+      ) : (
+        <>
+          <div className="mb-6">
+            <Line data={chartData} />
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Original URL
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Short Code
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Number of clicks
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Date created
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {links.map((link) => (
+                  <tr key={link.shortCode}>
+                    <td className="px-6 py-4 break-all">{link.originalUrl}</td>
+                    <td className="px-6 py-4">{link.shortCode}</td>
+                    <td className="px-6 py-4 text-center">{link.clicks}</td>
+                    <td className="px-6 py-4">
+                      {new Date(link.createdAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default AdminDashboard

--- a/src/pages/AdminLogin.jsx
+++ b/src/pages/AdminLogin.jsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { toast } from 'react-toastify'
+
+function AdminLogin() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const res = await axios.post('/api/admin/login', { email, password })
+      localStorage.setItem('token', res.data.token)
+      toast.success('Login successful')
+      navigate('/admin')
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100 p-4">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Admin Login</h1>
+        <input
+          className="w-full border p-2 rounded"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          className="w-full bg-blue-500 text-white py-2 rounded disabled:opacity-50"
+          type="submit"
+          disabled={loading}
+        >
+          {loading ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default AdminLogin

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+
+function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
+      <Link to="/" className="text-blue-500 underline">Go Home</Link>
+    </div>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
## Summary
- scaffold admin login, protected routes, and 404 page
- integrate Chart.js trend graph in admin dashboard
- add toast notifications and router setup
- document project usage and API expectations
- remove Tailwind CDN script from HTML

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68546c9302d4832caed27b8e3b029d6d